### PR TITLE
#2 license headers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 plugins {
     java
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Feb 03 19:34:37 MSK 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 rootProject.name = 'liho'
 

--- a/src/main/java/ru/arsysop/liho/Cashed.java
+++ b/src/main/java/ru/arsysop/liho/Cashed.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho;
 
 import java.util.ArrayList;

--- a/src/main/java/ru/arsysop/liho/check/Comment.java
+++ b/src/main/java/ru/arsysop/liho/check/Comment.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import ru.arsysop.liho.file.File;

--- a/src/main/java/ru/arsysop/liho/check/CommentSearchEngine.java
+++ b/src/main/java/ru/arsysop/liho/check/CommentSearchEngine.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import java.util.ArrayList;
@@ -21,7 +33,7 @@ public abstract class CommentSearchEngine {
 		if (completed.get()) {
 			throw new IllegalStateException("Cannot update state after it's completed");
 		}
-		updateFound(line); // redesign to avoid temporal coupling here
+		updateFound(line); // TODO: redesign to avoid temporal coupling here. vertical delegation?
 		updateContent(line);
 		updateCompleted(line);
 	}

--- a/src/main/java/ru/arsysop/liho/check/CopyrightSegmentCheck.java
+++ b/src/main/java/ru/arsysop/liho/check/CopyrightSegmentCheck.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import ru.arsysop.liho.Cashed;

--- a/src/main/java/ru/arsysop/liho/check/HeadingComment.java
+++ b/src/main/java/ru/arsysop/liho/check/HeadingComment.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import ru.arsysop.liho.file.File;

--- a/src/main/java/ru/arsysop/liho/check/SPDXSegmentCheck.java
+++ b/src/main/java/ru/arsysop/liho/check/SPDXSegmentCheck.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import ru.arsysop.liho.Cashed;

--- a/src/main/java/ru/arsysop/liho/check/SegmentCheck.java
+++ b/src/main/java/ru/arsysop/liho/check/SegmentCheck.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import ru.arsysop.liho.report.IssueType;

--- a/src/main/java/ru/arsysop/liho/check/issues/FileNotAccessible.java
+++ b/src/main/java/ru/arsysop/liho/check/issues/FileNotAccessible.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.issues;
 
 import ru.arsysop.liho.report.IssueType;

--- a/src/main/java/ru/arsysop/liho/check/issues/NoCopyright.java
+++ b/src/main/java/ru/arsysop/liho/check/issues/NoCopyright.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.issues;
 
 import ru.arsysop.liho.report.IssueType;

--- a/src/main/java/ru/arsysop/liho/check/issues/NoSpdx.java
+++ b/src/main/java/ru/arsysop/liho/check/issues/NoSpdx.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.issues;
 
 import ru.arsysop.liho.report.IssueType;

--- a/src/main/java/ru/arsysop/liho/check/java/BlockComment.java
+++ b/src/main/java/ru/arsysop/liho/check/java/BlockComment.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.java;
 
 import ru.arsysop.liho.check.CommentSearchEngine;

--- a/src/main/java/ru/arsysop/liho/check/java/JavaComment.java
+++ b/src/main/java/ru/arsysop/liho/check/java/JavaComment.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.java;
 
 import ru.arsysop.liho.check.HeadingComment;

--- a/src/main/java/ru/arsysop/liho/check/java/LineComment.java
+++ b/src/main/java/ru/arsysop/liho/check/java/LineComment.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.java;
 
 import ru.arsysop.liho.check.CommentSearchEngine;

--- a/src/main/java/ru/arsysop/liho/config/Config.java
+++ b/src/main/java/ru/arsysop/liho/config/Config.java
@@ -1,8 +1,20 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.config;
 
 public class Config {
 	// {owner, sources owned}*
-	// min year of creation
+	// min inception year
 	// contributors?
 
 }

--- a/src/main/java/ru/arsysop/liho/file/Extension.java
+++ b/src/main/java/ru/arsysop/liho/file/Extension.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 import java.util.function.Supplier;

--- a/src/main/java/ru/arsysop/liho/file/File.java
+++ b/src/main/java/ru/arsysop/liho/file/File.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 import java.io.IOException;

--- a/src/main/java/ru/arsysop/liho/file/FileExtension.java
+++ b/src/main/java/ru/arsysop/liho/file/FileExtension.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 import ru.arsysop.liho.Cashed;

--- a/src/main/java/ru/arsysop/liho/file/FileFromPath.java
+++ b/src/main/java/ru/arsysop/liho/file/FileFromPath.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 import ru.arsysop.liho.Cashed;

--- a/src/main/java/ru/arsysop/liho/file/PredefinedExtension.java
+++ b/src/main/java/ru/arsysop/liho/file/PredefinedExtension.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 public final class PredefinedExtension extends Extension{

--- a/src/main/java/ru/arsysop/liho/report/IssueLocation.java
+++ b/src/main/java/ru/arsysop/liho/report/IssueLocation.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.report;
 
 import java.nio.file.Path;

--- a/src/main/java/ru/arsysop/liho/report/IssueType.java
+++ b/src/main/java/ru/arsysop/liho/report/IssueType.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.report;
 
 import java.util.Objects;

--- a/src/main/java/ru/arsysop/liho/report/Report.java
+++ b/src/main/java/ru/arsysop/liho/report/Report.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.report;
 
 public interface Report {

--- a/src/test/java/ru/arsysop/liho/TestResource.java
+++ b/src/test/java/ru/arsysop/liho/TestResource.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho;
 
 import ru.arsysop.liho.file.File;
@@ -12,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public final class TestResource {
+
 	private final Cashed<String, File> file;
 	private final Cashed<String, Path> path;
 
@@ -46,6 +59,5 @@ public final class TestResource {
 		assumeTrue(resource != null);
 		return resource;
 	}
-
 
 }

--- a/src/test/java/ru/arsysop/liho/check/CopyrightCheckTest.java
+++ b/src/test/java/ru/arsysop/liho/check/CopyrightCheckTest.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/ru/arsysop/liho/check/java/BlockCommentTest.java
+++ b/src/test/java/ru/arsysop/liho/check/java/BlockCommentTest.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.java;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/ru/arsysop/liho/check/java/JavaCommentTest.java
+++ b/src/test/java/ru/arsysop/liho/check/java/JavaCommentTest.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.java;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/ru/arsysop/liho/check/java/LineCommentTest.java
+++ b/src/test/java/ru/arsysop/liho/check/java/LineCommentTest.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.check.java;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/ru/arsysop/liho/file/FileExtensionTest.java
+++ b/src/test/java/ru/arsysop/liho/file/FileExtensionTest.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/ru/arsysop/liho/file/FileFromPathTest.java
+++ b/src/test/java/ru/arsysop/liho/file/FileFromPathTest.java
@@ -1,3 +1,15 @@
+/********************************************************************************
+ * Copyright (c) 2020 ArSysOp
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   ArSysOp - initial API and implementation
+ ********************************************************************************/
 package ru.arsysop.liho.file;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
- entitle all source files and build scripts with license headers
- switch gradle to the talest version 6.1.1