### PR TITLE
Prepare release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,19 +28,13 @@ plugins {
 group = "ru.arsysop.liho"
 version = "0.1"
 
-project.apply {
-    description =
-        "License Header verification tool: checks if license header in all your project source base file fits Eclipse Foundation Project Handbook (https://www.eclipse.org/projects/handbook/#ip-copyright-headers"
-}
-
 repositories {
     mavenCentral()
     jcenter()
-    maven(url = "https://dl.bintray.com/arsysop/lang")
 }
 
 dependencies {
-    implementation("ru.arsysop:ru.arsysop.lang:0.1")
+    implementation("ru.arsysop.lang:lang:0.1")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.0")
 }
@@ -94,14 +88,17 @@ tasks.getByName("sourcesJar") {
 }
 
 fun extendManifest(mf: Manifest) {
+    val bundle: String by project
+    val copyright: String by project
     mf.attributes(
         "Bundle-Vendor" to "ArSysOp",
-        "Bundle-Name" to "ru.arsysop.liho",
+        "Bundle-Name" to bundle,
         "Bundle-SymbolicName" to "ru.arsysop.liho",
         "Bundle-Version" to project.version,
         "Automatic-Module-Name" to "ru.arsysop.liho",
         "Bundle-ManifestVersion" to "2",
         "Bundle-RequiredExecutionEnvironment" to "JavaSE-1.8",
+        "Bundle-Copyright" to copyright,
         "Export-Package" to
                 listOf("ru.arsysop.liho.report", "ru.arsysop.liho.bulk")
                     .map { it + ";version=${project.version}" }
@@ -128,7 +125,8 @@ publishing {
             from(components["java"])
             pom {
                 name.set(project.name)
-                description.set(project.description)
+                val explanation: String by project
+                description.set(explanation)
                 url.set("https://github.com/ArSysOp/liho")
                 licenses {
                     license {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,24 @@
+###############################################################################
+# Copyright (c) 2020 ArSysOp
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Contributors:
+#     ArSysOp - initial API and implementation
+###############################################################################
+
 copyright = Copyright (c) 2020 ArSysOp and others. This program and the accompanying materials are made available under the terms of the Apache 2.0 License which is available at http://www.apache.org/licenses/LICENSE-2.0. SPDX-License-Identifier: Apache-2.0
 bundle = ArSysOp LiHo
 explanation = License Header verification tool: checks if license header in all your project source base file fits Eclipse Foundation Project Handbook (https://www.eclipse.org/projects/handbook/#ip-copyright-headers

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+copyright = Copyright (c) 2020 ArSysOp and others. This program and the accompanying materials are made available under the terms of the Apache 2.0 License which is available at http://www.apache.org/licenses/LICENSE-2.0. SPDX-License-Identifier: Apache-2.0
+bundle = ArSysOp LiHo
+explanation = License Header verification tool: checks if license header in all your project source base file fits Eclipse Foundation Project Handbook (https://www.eclipse.org/projects/handbook/#ip-copyright-headers

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,6 @@ pluginManagement {
         gradlePluginPortal()
         mavenLocal()
         jcenter()
-        maven(url = "https://dl.bintray.com/arsysop/lang")
         maven(url = "https://dl.bintray.com/arsysop/liho")
     }
     resolutionStrategy {


### PR DESCRIPTION
Release preparations: 

- switch `lang` reference to jcenter() as it has just been published
- improve build procedure by extracting explanatory things to gradle.properties